### PR TITLE
check U2 perk string import against U2 perk levels

### DIFF
--- a/main.js
+++ b/main.js
@@ -3119,7 +3119,9 @@ function importPerks() {
 		if (game.portal[perk].locked || level > game.portal[perk].max || isNumberBad(level))
 			return "Cannot set " + perk + " to level " + level + ".";
 
-		if (level < game.portal[perk].level)
+		if (portalUniverse == 1 && level < game.portal[perk].level)
+			respecNeeded = true;			
+		if (portalUniverse == 2 && level < game.portal[perk].radLevel)
 			respecNeeded = true;
 
 		changeAmt[perk] = level - game.portal[perk][levelName] - game.portal[perk].levelTemp;


### PR DESCRIPTION
Prior to this change, respecNeeded was calculated for U2 perk string import by comparing against U1 perk levels. This meant U2 perk string import would essentially always require a respec in normal usage, but was also open to exploits by deleting U1 perk levels before entering U2.